### PR TITLE
Stream large message processing

### DIFF
--- a/pkg/armor/stream.go
+++ b/pkg/armor/stream.go
@@ -1,0 +1,149 @@
+package armor
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+// MessageWriter streams ASCII armor output for PGP MESSAGE blocks.
+type MessageWriter struct {
+	blockType  string
+	w          io.Writer
+	enc        io.WriteCloser
+	breaker    *lineBreaker
+	includeCRC bool
+	crc        uint32
+	wroteData  bool
+	closed     bool
+}
+
+// NewMessageWriter initializes a streaming ASCII armor writer.
+func NewMessageWriter(w io.Writer, blockType string, headers map[string]string, includeCRC bool) (*MessageWriter, error) {
+	if blockType == "" {
+		return nil, errors.New("armor: block type required")
+	}
+	mw := &MessageWriter{
+		blockType:  blockType,
+		w:          w,
+		includeCRC: includeCRC,
+		crc:        0xB704CE,
+	}
+
+	if _, err := fmt.Fprintf(w, "-----BEGIN %s-----\n", blockType); err != nil {
+		return nil, err
+	}
+	if len(headers) > 0 {
+		keys := make([]string, 0, len(headers))
+		for k := range headers {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, err := fmt.Fprintf(w, "%s: %s\n", k, headers[k]); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if _, err := io.WriteString(w, "\n"); err != nil {
+		return nil, err
+	}
+
+	mw.breaker = &lineBreaker{w: w}
+	mw.enc = base64.NewEncoder(base64.StdEncoding, mw.breaker)
+	return mw, nil
+}
+
+// NewPGPMessageWriter returns a MessageWriter for "PGP MESSAGE" blocks.
+func NewPGPMessageWriter(w io.Writer, headers map[string]string, includeCRC bool) (*MessageWriter, error) {
+	return NewMessageWriter(w, "PGP MESSAGE", headers, includeCRC)
+}
+
+// Write streams data into the armor encoder.
+func (mw *MessageWriter) Write(p []byte) (int, error) {
+	if mw.closed {
+		return 0, errors.New("armor: write on closed message writer")
+	}
+	if mw.includeCRC {
+		for _, b := range p {
+			mw.crc = crc24UpdateByte(mw.crc, b)
+		}
+	}
+	if len(p) > 0 {
+		mw.wroteData = true
+	}
+	return mw.enc.Write(p)
+}
+
+// Close flushes base64 output and writes the footer.
+func (mw *MessageWriter) Close() error {
+	if mw.closed {
+		return nil
+	}
+	mw.closed = true
+	if err := mw.enc.Close(); err != nil {
+		return err
+	}
+	if err := mw.breaker.Close(); err != nil {
+		return err
+	}
+
+	if mw.includeCRC {
+		crc := mw.crc & 0xFFFFFF
+		crcBytes := []byte{byte((crc >> 16) & 0xFF), byte((crc >> 8) & 0xFF), byte(crc & 0xFF)}
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(crcBytes)))
+		base64.StdEncoding.Encode(buf, crcBytes)
+		if _, err := fmt.Fprintf(mw.w, "=%s\n", string(buf)); err != nil {
+			return err
+		}
+	} else if !mw.wroteData {
+		if _, err := io.WriteString(mw.w, "\n"); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(mw.w, "-----END %s-----\n", mw.blockType)
+	return err
+}
+
+type lineBreaker struct {
+	w   io.Writer
+	col int
+}
+
+func (lb *lineBreaker) Write(p []byte) (int, error) {
+	for i, b := range p {
+		if lb.col == 64 {
+			if _, err := lb.w.Write([]byte{'\n'}); err != nil {
+				return i, err
+			}
+			lb.col = 0
+		}
+		if _, err := lb.w.Write([]byte{b}); err != nil {
+			return i, err
+		}
+		lb.col++
+	}
+	return len(p), nil
+}
+
+func (lb *lineBreaker) Close() error {
+	if lb.col > 0 {
+		if _, err := lb.w.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func crc24UpdateByte(crc uint32, b byte) uint32 {
+	crc ^= uint32(b) << 16
+	for i := 0; i < 8; i++ {
+		crc <<= 1
+		if (crc & 0x1000000) != 0 {
+			crc ^= 0x1864CF
+		}
+	}
+	return crc & 0xFFFFFF
+}

--- a/pkg/pgp/ocbed_decrypt_stream.go
+++ b/pkg/pgp/ocbed_decrypt_stream.go
@@ -1,0 +1,102 @@
+package pgp
+
+import (
+	"crypto/aes"
+	"encoding/binary"
+	"errors"
+	"io"
+
+	pmocb "github.com/ProtonMail/go-crypto/ocb"
+)
+
+// DecryptOCBEDStream decrypts a Tag 20 body into dst without loading the full ciphertext in memory.
+func DecryptOCBEDStream(dst io.Writer, body io.Reader, bodyLen int64, cek []byte) error {
+	if len(cek) != 16 && len(cek) != 24 && len(cek) != 32 {
+		return errors.New("bad key length")
+	}
+	if bodyLen < 4+15+16 {
+		return errors.New("short ocbed")
+	}
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(body, header); err != nil {
+		return err
+	}
+	version := header[0]
+	sym := header[1]
+	mode := header[2]
+	bits := int(header[3])
+	if bits <= 0 || bits > 30 {
+		return errChunkBits
+	}
+	chunkSize := 1 << bits
+
+	iv := make([]byte, 15)
+	if _, err := io.ReadFull(body, iv); err != nil {
+		return err
+	}
+
+	cipherLen := bodyLen - 4 - 15
+	if cipherLen < 16 {
+		return errors.New("short ocbed ciphertext")
+	}
+	dataLen := cipherLen - 16
+
+	block, err := aes.NewCipher(cek)
+	if err != nil {
+		return err
+	}
+	aead, err := pmocb.NewOCB(block)
+	if err != nil {
+		return err
+	}
+
+	aad := []byte{0xD4, version, sym, mode, byte(bits), 0, 0, 0, 0, 0, 0, 0, 0}
+
+	nonce := make([]byte, 15)
+	base := binary.BigEndian.Uint64(iv[7:])
+
+	buf := make([]byte, chunkSize+16)
+	dataReader := io.LimitReader(body, dataLen)
+
+	var chunkIndex uint64
+	var totalPlain uint64
+	for remaining := dataLen; remaining > 0; {
+		toRead := chunkSize + 16
+		if int64(toRead) > remaining {
+			toRead = int(remaining)
+		}
+		if toRead < 16 {
+			return errors.New("ocbed chunk too small")
+		}
+		n, err := io.ReadFull(dataReader, buf[:toRead])
+		if err != nil {
+			return err
+		}
+		copy(nonce, iv)
+		binary.BigEndian.PutUint64(nonce[7:], base+chunkIndex)
+		pt, err := aead.Open(nil, nonce, buf[:n], aad)
+		if err != nil {
+			return err
+		}
+		if _, err := dst.Write(pt); err != nil {
+			return err
+		}
+		totalPlain += uint64(len(pt))
+		chunkIndex++
+		remaining -= int64(n)
+	}
+
+	finalTag := make([]byte, 16)
+	if _, err := io.ReadFull(body, finalTag); err != nil {
+		return err
+	}
+	finalAAD := append(append([]byte{}, aad...), u64be(totalPlain)...)
+	copy(nonce, iv)
+	binary.BigEndian.PutUint64(nonce[7:], base+chunkIndex)
+	expected := aead.Seal(nil, nonce, nil, finalAAD)
+	if !bytesEqual(expected, finalTag) {
+		return errors.New("final tag mismatch")
+	}
+	return nil
+}

--- a/pkg/pgp/ocbed_stream.go
+++ b/pkg/pgp/ocbed_stream.go
@@ -1,0 +1,102 @@
+package pgp
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"io"
+
+	pmocb "github.com/ProtonMail/go-crypto/ocb"
+)
+
+// WriteOCBEDStream writes a LibrePGP OCB Encrypted Data (Tag 20) body without buffering the plaintext.
+func WriteOCBEDStream(dst io.Writer, symAlg, chunkBits int, cek []byte, src io.Reader) (int64, error) {
+	if symAlg != SYM_AES192 && symAlg != SYM_AES256 && symAlg != SYM_AES128 {
+		return 0, errors.New("unsupported sym alg")
+	}
+	if len(cek) != 16 && len(cek) != 24 && len(cek) != 32 {
+		return 0, errors.New("bad key length")
+	}
+	if chunkBits <= 0 || chunkBits > 30 {
+		return 0, errChunkBits
+	}
+	chunkSize := 1 << chunkBits
+
+	version := byte(1)
+	mode := byte(0x02)
+	chunkByte := byte(chunkBits & 0xFF)
+
+	iv := make([]byte, 15)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return 0, err
+	}
+
+	block, err := aes.NewCipher(cek)
+	if err != nil {
+		return 0, err
+	}
+	aead, err := pmocb.NewOCB(block)
+	if err != nil {
+		return 0, err
+	}
+
+	header := []byte{version, byte(symAlg), mode, chunkByte}
+	var written int64
+	n, err := dst.Write(header)
+	written += int64(n)
+	if err != nil {
+		return written, err
+	}
+	n, err = dst.Write(iv)
+	written += int64(n)
+	if err != nil {
+		return written, err
+	}
+
+	aad := []byte{0xD4, version, byte(symAlg), mode, chunkByte, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	buf := make([]byte, chunkSize)
+	nonce := make([]byte, 15)
+	base := binary.BigEndian.Uint64(iv[7:])
+
+	var chunkIndex uint64
+	var totalPlain uint64
+	for {
+		n, readErr := io.ReadAtLeast(src, buf, chunkSize)
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil && readErr != io.ErrUnexpectedEOF {
+			return written, readErr
+		}
+		if readErr == io.ErrUnexpectedEOF {
+			n = len(buf[:n])
+		}
+		if n == 0 {
+			break
+		}
+
+		copy(nonce, iv)
+		binary.BigEndian.PutUint64(nonce[7:], base+chunkIndex)
+		ct := aead.Seal(nil, nonce, buf[:n], aad)
+		totalPlain += uint64(n)
+		chunkIndex++
+		n2, err := dst.Write(ct)
+		written += int64(n2)
+		if err != nil {
+			return written, err
+		}
+		if readErr == io.ErrUnexpectedEOF {
+			break
+		}
+	}
+
+	copy(nonce, iv)
+	binary.BigEndian.PutUint64(nonce[7:], base+chunkIndex)
+	finalAAD := append(append([]byte{}, aad...), u64be(totalPlain)...)
+	finalTag := aead.Seal(nil, nonce, nil, finalAAD)
+	n, err = dst.Write(finalTag)
+	written += int64(n)
+	return written, err
+}

--- a/pkg/pgp/packet.go
+++ b/pkg/pgp/packet.go
@@ -1,6 +1,12 @@
 package pgp
 
-import "bytes"
+import (
+	"bytes"
+	"errors"
+	"io"
+)
+
+var errShortHeader = errors.New("pgp: short packet header")
 
 // writeNewFormatHeader builds a RFC 9580 new-format packet header.
 func writeNewFormatHeader(tag byte, bodyLen int) []byte {
@@ -11,7 +17,7 @@ func writeNewFormatHeader(tag byte, bodyLen int) []byte {
 		hdr.WriteByte(byte(bodyLen))
 	} else if bodyLen <= 8383 {
 		bodyLen -= 192
-		hdr.WriteByte(byte(192 + (bodyLen>>8)))
+		hdr.WriteByte(byte(192 + (bodyLen >> 8)))
 		hdr.WriteByte(byte(bodyLen & 0xFF))
 	} else {
 		hdr.WriteByte(0xFF)
@@ -31,27 +37,89 @@ func Packet(tag byte, body []byte) []byte {
 	return out
 }
 
+// WritePacketHeader writes a new-format packet header for the given tag/bodyLen.
+func WritePacketHeader(w io.Writer, tag byte, bodyLen int) error {
+	hdr := writeNewFormatHeader(tag, bodyLen)
+	_, err := w.Write(hdr)
+	return err
+}
+
+// ReadPacketHeader reads a new-format packet header from r and returns the tag and body length.
+func ReadPacketHeader(r io.Reader) (tag byte, bodyLen int, err error) {
+	var first [1]byte
+	if _, err = io.ReadFull(r, first[:]); err != nil {
+		if err == io.EOF {
+			return 0, 0, errShortHeader
+		}
+		return 0, 0, err
+	}
+	h := first[0]
+	if (h & 0xC0) != 0xC0 {
+		return 0, 0, ErrPacket
+	}
+	tag = h & 0x3F
+
+	var lenByte [1]byte
+	if _, err = io.ReadFull(r, lenByte[:]); err != nil {
+		if err == io.EOF {
+			return 0, 0, errShortHeader
+		}
+		return 0, 0, err
+	}
+	b := lenByte[0]
+	switch {
+	case b < 192:
+		bodyLen = int(b)
+	case b <= 223:
+		var next [1]byte
+		if _, err = io.ReadFull(r, next[:]); err != nil {
+			return 0, 0, err
+		}
+		bodyLen = (int(b)-192)<<8 + int(next[0]) + 192
+	case b == 255:
+		var buf [4]byte
+		if _, err = io.ReadFull(r, buf[:]); err != nil {
+			return 0, 0, err
+		}
+		bodyLen = int(buf[0])<<24 | int(buf[1])<<16 | int(buf[2])<<8 | int(buf[3])
+	default:
+		return 0, 0, ErrPacket
+	}
+	return tag, bodyLen, nil
+}
+
 // ReadPacket parses a single new-format packet and returns (tag, body, rest).
 func ReadPacket(b []byte) (byte, []byte, []byte, error) {
-	if len(b) < 2 { return 0, nil, nil, ErrPacket }
+	if len(b) < 2 {
+		return 0, nil, nil, ErrPacket
+	}
 	h := b[0]
-	if (h & 0xC0) != 0xC0 { return 0, nil, nil, ErrPacket }
+	if (h & 0xC0) != 0xC0 {
+		return 0, nil, nil, ErrPacket
+	}
 	tag := h & 0x3F
 	b = b[1:]
 	var n int
 	if b[0] < 192 {
-		n = int(b[0]); b = b[1:]
+		n = int(b[0])
+		b = b[1:]
 	} else if b[0] <= 223 {
-		if len(b) < 2 { return 0, nil, nil, ErrPacket }
+		if len(b) < 2 {
+			return 0, nil, nil, ErrPacket
+		}
 		n = int(b[0]-192)<<8 + int(b[1]) + 192
 		b = b[2:]
 	} else if b[0] == 255 {
-		if len(b) < 5 { return 0, nil, nil, ErrPacket }
+		if len(b) < 5 {
+			return 0, nil, nil, ErrPacket
+		}
 		n = int(b[1])<<24 | int(b[2])<<16 | int(b[3])<<8 | int(b[4])
 		b = b[5:]
 	} else {
 		return 0, nil, nil, ErrPacket
 	}
-	if len(b) < n { return 0, nil, nil, ErrPacket }
+	if len(b) < n {
+		return 0, nil, nil, ErrPacket
+	}
 	return tag, b[:n], b[n:], nil
 }

--- a/pkg/pgp/seipdv2ocb_decrypt_stream.go
+++ b/pkg/pgp/seipdv2ocb_decrypt_stream.go
@@ -1,0 +1,117 @@
+package pgp
+
+import (
+	"crypto/aes"
+	"errors"
+	"io"
+
+	pmocb "github.com/ProtonMail/go-crypto/ocb"
+)
+
+// DecryptSEIPDv2OCBStream decrypts a v2 SEIPD (Tag 18) body and writes the
+// plaintext to dst without buffering the entire ciphertext in memory.
+func DecryptSEIPDv2OCBStream(dst io.Writer, body io.Reader, bodyLen int64, sessionKey []byte) error {
+	if len(sessionKey) != 16 && len(sessionKey) != 24 && len(sessionKey) != 32 {
+		return errors.New("bad session key length")
+	}
+	if bodyLen < 4+32+16 {
+		return errors.New("short seipd")
+	}
+
+	header := make([]byte, 4)
+	if _, err := io.ReadFull(body, header); err != nil {
+		return err
+	}
+	version := header[0]
+	sym := header[1]
+	aeadAlg := header[2]
+	bits := int(header[3])
+	if bits <= 0 || bits > 30 {
+		return errChunkBits
+	}
+	chunkSize := 1 << bits
+
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(body, salt); err != nil {
+		return err
+	}
+
+	cipherLen := bodyLen - 4 - 32
+	if cipherLen < 16 {
+		return errors.New("short seipd ciphertext")
+	}
+	dataLen := cipherLen - 16
+
+	mk, iv7, err := kdfSEIPDv2HKDF(sessionKey, salt, version, sym, aeadAlg, byte(bits))
+	if err != nil {
+		return err
+	}
+	block, err := aes.NewCipher(mk)
+	if err != nil {
+		return err
+	}
+	aead, err := pmocb.NewOCB(block)
+	if err != nil {
+		return err
+	}
+
+	aad := []byte{0xD2, version, sym, aeadAlg, byte(bits)}
+
+	nonce := make([]byte, 15)
+	copy(nonce[:7], iv7)
+
+	buf := make([]byte, chunkSize+16)
+	dataReader := io.LimitReader(body, dataLen)
+
+	var chunkIndex uint64
+	var totalPlain uint64
+	for remaining := dataLen; remaining > 0; {
+		toRead := chunkSize + 16
+		if int64(toRead) > remaining {
+			toRead = int(remaining)
+		}
+		if toRead < 16 {
+			return errors.New("seipd chunk too small")
+		}
+		n, err := io.ReadFull(dataReader, buf[:toRead])
+		if err != nil {
+			return err
+		}
+		chunk := buf[:n]
+		copy(nonce[7:], u64be(chunkIndex))
+		pt, err := aead.Open(nil, nonce, chunk, aad)
+		if err != nil {
+			return err
+		}
+		if _, err := dst.Write(pt); err != nil {
+			return err
+		}
+		totalPlain += uint64(len(pt))
+		chunkIndex++
+		remaining -= int64(n)
+	}
+
+	finalTag := make([]byte, 16)
+	if _, err := io.ReadFull(body, finalTag); err != nil {
+		return err
+	}
+	finalAAD := append(append([]byte{}, aad...), u64be(totalPlain)...)
+	copy(nonce[:7], iv7)
+	copy(nonce[7:], u64be(chunkIndex))
+	expected := aead.Seal(nil, nonce, nil, finalAAD)
+	if !bytesEqual(expected, finalTag) {
+		return errors.New("final tag mismatch")
+	}
+	return nil
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var v byte
+	for i := range a {
+		v |= a[i] ^ b[i]
+	}
+	return v == 0
+}

--- a/pkg/pgp/seipdv2ocb_stream.go
+++ b/pkg/pgp/seipdv2ocb_stream.go
@@ -1,0 +1,110 @@
+package pgp
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"errors"
+	"io"
+
+	pmocb "github.com/ProtonMail/go-crypto/ocb"
+)
+
+var errChunkBits = errors.New("pgp: invalid chunk bits")
+
+// WriteSEIPDv2OCBStream writes a v2 SEIPD (Tag 18) body to dst encrypting
+// plaintext read from src. The returned int64 is the number of bytes written to dst.
+func WriteSEIPDv2OCBStream(dst io.Writer, symAlg, chunkBits int, sessionKey []byte, src io.Reader) (int64, error) {
+	if symAlg != SYM_AES192 && symAlg != SYM_AES256 && symAlg != SYM_AES128 {
+		return 0, errors.New("unsupported sym alg")
+	}
+	if len(sessionKey) != 16 && len(sessionKey) != 24 && len(sessionKey) != 32 {
+		return 0, errors.New("bad session key length")
+	}
+	if chunkBits <= 0 || chunkBits > 30 {
+		return 0, errChunkBits
+	}
+	chunkSize := 1 << chunkBits
+
+	version := byte(2)
+	aeadAlg := byte(AEAD_OCB)
+	chunkSizeByte := byte(chunkBits & 0xFF)
+
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return 0, err
+	}
+
+	mk, iv7, err := kdfSEIPDv2HKDF(sessionKey, salt, version, byte(symAlg), aeadAlg, chunkSizeByte)
+	if err != nil {
+		return 0, err
+	}
+
+	aad := []byte{0xD2, version, byte(symAlg), aeadAlg, chunkSizeByte}
+
+	block, err := aes.NewCipher(mk)
+	if err != nil {
+		return 0, err
+	}
+	aead, err := pmocb.NewOCB(block)
+	if err != nil {
+		return 0, err
+	}
+
+	var written int64
+	header := []byte{version, byte(symAlg), aeadAlg, chunkSizeByte}
+	n, err := dst.Write(header)
+	written += int64(n)
+	if err != nil {
+		return written, err
+	}
+	n, err = dst.Write(salt)
+	written += int64(n)
+	if err != nil {
+		return written, err
+	}
+
+	buf := make([]byte, chunkSize)
+	nonce := make([]byte, 15)
+	copy(nonce[:7], iv7)
+
+	var chunkIndex uint64
+	var totalPlain uint64
+	for {
+		n, readErr := io.ReadAtLeast(src, buf, chunkSize)
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil && readErr != io.ErrUnexpectedEOF {
+			return written, readErr
+		}
+
+		if readErr == io.ErrUnexpectedEOF {
+			n = len(buf[:n])
+		}
+		if n == 0 {
+			break
+		}
+
+		copy(nonce[7:], u64be(chunkIndex))
+		ct := aead.Seal(nil, nonce, buf[:n], aad)
+		totalPlain += uint64(n)
+		chunkIndex++
+		n2, err := dst.Write(ct)
+		written += int64(n2)
+		if err != nil {
+			return written, err
+		}
+
+		if readErr == io.ErrUnexpectedEOF {
+			break
+		}
+	}
+
+	finalAAD := append(append([]byte{}, aad...), u64be(totalPlain)...)
+	copy(nonce[:7], iv7)
+	copy(nonce[7:], u64be(chunkIndex))
+	finalTag := aead.Seal(nil, nonce, nil, finalAAD)
+	n, err = dst.Write(finalTag)
+	written += int64(n)
+	return written, err
+}


### PR DESCRIPTION
## Summary
- stream CLI encryption/decryption to avoid buffering, including ASCII armor streaming and armor decoding helpers
- add packet header helpers and streaming SEIPDv2/OCBED encoders and decoders for large payloads
- introduce a streaming ASCII armor writer to emit armored messages without buffering

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da44162068832d8837f1cf7f471b9f