### PR TITLE
Avoid writing raw key files when armor is requested

### DIFF
--- a/cmd/gocrypt/main.go
+++ b/cmd/gocrypt/main.go
@@ -436,7 +436,6 @@ func keygen(args []string) {
 			}
 			if out != "" {
 				writeKeyArmor(out, armPub, armSec)
-				writeKeyFiles(out, pubB64, privB64)
 			}
 		} else {
 			if out == "" {
@@ -466,7 +465,6 @@ func keygen(args []string) {
 			}
 			if out != "" {
 				writeKeyArmor(out, armPub, armSec)
-				writeKeyFiles(out, pubB64, privB64)
 			}
 		} else {
 			if out == "" {


### PR DESCRIPTION
## Summary
- stop the key generator from writing raw .pub/.key files when --armor is used
- keep armored key material output unchanged

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da53e845a8832d8fe0a816106fe68c